### PR TITLE
LPS-89596: Cannot Drag Image from top content line in IE11 using Alloy Editor

### DIFF
--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -1470,7 +1470,7 @@
 					y: domElement.offsetTop - DRAG_HANDLER_SIZE
 				};
 
-			if ( CKEDITOR.env.ie && CKEDITOR.env.version == 11 ) {
+			if ( CKEDITOR.env.ie ) {
 				newPos.y = 0;
 			}
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -1470,6 +1470,10 @@
 					y: domElement.offsetTop - DRAG_HANDLER_SIZE
 				};
 
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version == 11 ) {
+				newPos.y = 0;
+			}
+
 			if ( oldPos && newPos.x == oldPos.x && newPos.y == oldPos.y )
 				return;
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-89596

Issue:
Images were not able to be moved after being added or moved to the first line in AlloyEditor.

Resolution:
Moved the drag icon to be visible in IE11 to allow users to move image after being dropped to the first line in AlloyEditor.