### PR TITLE
LPS-90595

### DIFF
--- a/core/dom/domobject.js
+++ b/core/dom/domobject.js
@@ -146,9 +146,16 @@ CKEDITOR.dom.domObject.prototype = ( function() {
 
 ( function( domObjectProto ) {
 	var customData = {};
+	var customDataElements = [];
 
 	CKEDITOR.on( 'reset', function() {
 		customData = {};
+
+		for (var i = 0; i < customDataElements.length; i++) {
+			delete customDataElements[i].$[ 'data-cke-expando' ];
+		}
+
+		customDataElements = [];
 	} );
 
 	/**
@@ -257,7 +264,19 @@ CKEDITOR.dom.domObject.prototype = ( function() {
 	 * @returns {Number} A unique ID.
 	 */
 	domObjectProto.getUniqueId = function() {
-		return this.$[ 'data-cke-expando' ] || ( this.$[ 'data-cke-expando' ] = CKEDITOR.tools.getNextNumber() );
+		var expandoNumber = this.$[ 'data-cke-expando' ];
+
+		if (expandoNumber) {
+			return expandoNumber;
+		}
+
+		expandoNumber = CKEDITOR.tools.getNextNumber();
+
+		this.$[ 'data-cke-expando' ] = expandoNumber;
+
+		customDataElements.push(this);
+
+		return expandoNumber;
 	};
 
 	// Implement CKEDITOR.event.


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-90595

I've found that CKEditor creates the equivalent of custom data fields for HTML elements with a special mapping object (it's functionally similar to Liferay's expando table). In this mapping object, the key is intended to be an auto-incrementing key that starts over from 0, and the auto-incremented key is cached as a "data-cke-expando" attribute on the HTML element. This allows you to lookup the custom data field values at a later time.

However, the "data-cke-expando" attribute on the document does not get cleared when navigating between pages via senna.js. Therefore, it's possible for the value that's cached on the document object to conflict with the auto-incrementing key intended for a completely different HTML element (effectively, this results in the same error state as having a hash key collision in a naive hash map implementation that lacks a linked list). As a result, whenever assigning custom data values, you end up attaching it to the wrong element.

By chance, this conflict between the auto-incrementing key and the "data-cke-expando" attribute set on the document doesn't happen on 7.1.x or on master, but it does happen in 7.0.x, resulting in the behavior described in [LPS-90595](https://issues.liferay.com/browse/LPS-90595).